### PR TITLE
Fix regex for array of prefix

### DIFF
--- a/lib/metric.rb
+++ b/lib/metric.rb
@@ -33,7 +33,7 @@ class Metric
       if prefix.nil?
         @metrics = json 
       elsif prefix.kind_of?(Array)
-        @metrics = json.grep(/^[#{prefix.map! { |k| Regexp.escape k }.join("|")}]/)
+        @metrics = json.grep(/^(#{prefix.map! { |k| Regexp.escape k }.join("|")})/)
       else
         @metrics = json.grep(/^#{Regexp.escape prefix}/)
       end


### PR DESCRIPTION
Follow up to pull #46:

I made a small mistake in building the regex for multiple prefix: It needs to be `^(stats|stats_count)` instead of `^[stats|stats_count]` (which accepts metrics with every character inside of `[..]`).