### PR TITLE
Fix deprecated :rubygems source in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,4 @@
-# A sample Gemfile
-source :rubygems
+source 'https://rubygems.org'
 
 gem 'rake'
 gem 'rack', '1.3.5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
     archive-tar-minitar (0.5.2)
     backports (2.6.1)


### PR DESCRIPTION
`bundle` scoffs at this syntax nowadays. Everything works fine over HTTPS, which is the preferred way to do this.

I also removed the 'sample gemfile' comment, since this is no longer a sample file