### PR TITLE
Upgrading and removing gems for ruby 2.2 compatibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,6 @@ end
 group :development do
   gem 'sinatra-reloader', :require => 'sinatra/reloader'
   gem 'thin'
-  gem 'ruby-debug19'
 end
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,6 @@ GEM
     backports (2.6.1)
     chunky_png (1.2.5)
     closure-compiler (1.1.6)
-    columnize (0.3.6)
     compass (0.12.1)
       chunky_png (~> 1.2)
       fssm (>= 0.2.7)
@@ -14,7 +13,7 @@ GEM
     downlow (0.1.4)
       archive-tar-minitar (>= 0.5.2)
       rubyzip (>= 0.9.4)
-    eventmachine (0.12.10)
+    eventmachine (1.0.8)
     ffi (1.0.11)
     fssm (0.2.9)
     haml (3.1.6)
@@ -25,9 +24,7 @@ GEM
       thor (~> 0.15)
       version_sorter (~> 1.1.0)
       yajl-ruby
-    kgio (2.7.4)
-    linecache19 (0.5.12)
-      ruby_core_source (>= 0.1.4)
+    kgio (2.10.0)
     listen (0.4.4)
       rb-fchange (~> 0.0.5)
       rb-fsevent (~> 0.9.1)
@@ -61,16 +58,6 @@ GEM
     redised (0.2.0)
       redis (~> 2)
       redis-namespace
-    ruby-debug-base19 (0.11.25)
-      columnize (>= 0.3.1)
-      linecache19 (>= 0.5.11)
-      ruby_core_source (>= 0.1.4)
-    ruby-debug19 (0.11.6)
-      columnize (>= 0.3.1)
-      linecache19 (>= 0.5.11)
-      ruby-debug-base19 (>= 0.11.19)
-    ruby_core_source (0.1.5)
-      archive-tar-minitar (>= 0.5.2)
     rubyzip (0.9.8)
     sass (3.1.19)
     sinatra (1.3.1)
@@ -120,7 +107,6 @@ DEPENDENCIES
   rake
   redis
   redised
-  ruby-debug19
   sinatra
   sinatra-contrib
   sinatra-reloader


### PR DESCRIPTION
removed ruby1.9 devel gems and upgraded eventmachine and kgio